### PR TITLE
Fix typo “Emphysize” in 0007-do-not-emphasize-line-headings.md

### DIFF
--- a/docs/decisions/0007-do-not-emphasize-line-headings.md
+++ b/docs/decisions/0007-do-not-emphasize-line-headings.md
@@ -12,7 +12,7 @@ MADR contains lines such as `Chosen option: "[option 1]"`. Should "Chosen option
 ## Considered Options
 
 * Do not emphasize line headings
-* Emphysize line headings
+* Emphasize line headings
 
 ## Decision Outcome
 


### PR DESCRIPTION
Fix typo