### PR TITLE
Add consulted and informed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Added front matter fields "consulted" and "informed" (inspired by [RACI](https://en.wikipedia.org/wiki/Responsibility_assignment_matrix#Role_distinction)). [#62](https://github.com/adr/madr/issues/62)
+
 ## [3.0.0-beta] – 2022-05-17
 
 ### Added

--- a/docs/decisions/0015-include-consulting-informed-of-raci.md
+++ b/docs/decisions/0015-include-consulting-informed-of-raci.md
@@ -1,0 +1,44 @@
+---
+parent: Decisions
+nav_order: 15
+---
+# Include "Consulted" and "Informed" of RACI
+
+## Context and Problem Statement
+
+We noticed an intersection between MADR and [RACI](https://en.wikipedia.org/wiki/Responsibility_assignment_matrix), and felt the need to add a "consulted" and "informed" field in addition to "deciders".
+Would it be beneficial to "upstream" these fields to MADR?
+
+MADR-Isse [#62](https://github.com/adr/madr/issues/62).
+
+## Decision Drivers
+
+* MADR should contain fields important to the ADR decision process
+* MADR template should be easy to understand
+* MADR should be lightweight
+
+## Considered Options
+
+* Include "Consulted" and "Informed" of RACI
+* Include all fields of RACI
+* Do not include anything of RACI
+
+## Decision Outcome
+
+Chosen option: "Include 'Consulted' and 'Informed' of RACI", because comes out best (see below).
+
+## Pros and Cons of the Options
+
+### Include "Consulted" and "Informed" of RACI
+
+* Good, because these two roles of RACI are well understood.
+* Good, because we make these fields optional, thus it keeps MADR still lightweight.
+* Bad, because it adds two additional fields
+
+### Include all fields of RACI
+
+This would add "Responsible", "Accountable", "Consulted", and "Informed"
+
+* Good, because complete RACI would be included
+* Bad, because get confused about who is "accountable" and who is "responsible".
+* Bad, because if decisions are mostly taken by consensus in small committees, then there might not be an "accountable" person.

--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -6,8 +6,10 @@ title: ADR Template
 
 # These are an optional element. Feel free to remove any of them.
 # status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}
-# deciders: {list everyone involved in the decision}
 # date: {YYYY-MM-DD when the decision was last updated}
+# deciders: {list everyone involved in the decision}
+# consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+# informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
 ---
 <!-- we need to disable MD025, because we use the different heading "ADR Template" in the homepage (see above) than it is foreseen in the template -->
 <!-- markdownlint-disable-file MD025 -->

--- a/template/adr-template.md
+++ b/template/adr-template.md
@@ -1,8 +1,10 @@
 ---
-# These are an optional element. Feel free to remove any of them.
+# These are optional elements. Feel free to remove any of them.
 status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}
-deciders: {list everyone involved in the decision}
 date: {YYYY-MM-DD when the decision was last updated}
+deciders: {list everyone involved in the decision}
+consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
 ---
 # {short title of solved problem and solution}
 


### PR DESCRIPTION
Fixes https://github.com/adr/madr/issues/62

@cristiklein On the one hand, I thought of adding "responsible" and "accountable", however this felt to be too much fields (even though "deciders"  says nothing about these two "roles". Nevertheless, for a "lean" template, it is OK. -- Should we add an ADR on that?