### PR TITLE
Add ADR-0016

### DIFF
--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -1,4 +1,5 @@
 ADRs
 MADR
+MADRs
 Nygard
 RACI

--- a/docs/decisions/0016-outcome-before-detailed-pros-cons.md
+++ b/docs/decisions/0016-outcome-before-detailed-pros-cons.md
@@ -1,0 +1,68 @@
+---
+parent: Decisions
+nav_order: 16
+---
+# Outcome before Detailed Pros and Cons
+
+## Context and Problem Statement
+
+MADR aims to list pros and cons of each option.
+Where should that list be placed?
+
+## Decision Drivers
+
+* MADR should be easy to write
+* MADR should be easy to read
+
+## Considered Options
+
+* Section "Pros and Cons of the Options" after "Decision Outcome"
+* Section "Pros and Cons of the Options" before "Decision Outcome"
+
+## Decision Outcome
+
+Chosen option: "Section 'Pros and Cons of the Options' after 'Decision Outcome'", because this keeps the available options and the decision outcome close together.
+
+## Pros and Cons of the Options
+
+### Section "Pros and Cons of the Options" after "Decision Outcome"
+
+Illustration:
+
+```markdown
+## Considered Options
+
+...
+
+## Decision Outcome
+
+...
+
+## Pros and Cons of the Options
+
+...
+```
+
+* Good, because this keeps the available options and the decision outcome close together.
+* Bad, because readers might be confused, because the logical flow broken: First comes the result, then the detailed arguments.
+
+### Section "Pros and Cons of the Options" before "Decision Outcome"
+
+Illustration:
+
+```markdown
+## Considered Options
+
+...
+
+## Pros and Cons of the Options
+
+...
+
+## Decision Outcome
+
+...
+```
+
+* Good, because the logical flow is kept
+* Bad, because the decision outcome is not close to the options

--- a/docs/decisions/0016-outcome-before-detailed-pros-cons.md
+++ b/docs/decisions/0016-outcome-before-detailed-pros-cons.md
@@ -11,8 +11,9 @@ Where should that list be placed?
 
 ## Decision Drivers
 
-* MADR should be easy to write
-* MADR should be easy to read
+* Most important information should be above the fold.
+* MADR should be easy to write.
+* MADR should be easy to read.
 
 ## Considered Options
 
@@ -22,6 +23,9 @@ Where should that list be placed?
 ## Decision Outcome
 
 Chosen option: "Section 'Pros and Cons of the Options' after 'Decision Outcome'", because this keeps the available options and the decision outcome close together.
+One gets the decision outcome above the fold and preserve a nice logical flow.
+Hence, one can see the "Pros and Cons" section as a sort of "appendix" to the considered options section.
+It is almost like the "Considered Options" section implies the following sentence: "For a more detailed analysis of these options, refer to pros and cons".
 
 ## Pros and Cons of the Options
 


### PR DESCRIPTION
Add ADR on putting "Pros and Cons of the Options" AFTER "Decision Outcome"

This discussion was raised when discussing on an ADR. One developer wondered why the outcome was put before the actual arguments.

I am thinking about putting `---` as separator before "Pros and Cons" to make it clear that this are details. However, this is also uncommon in Markdown files.

I would like to collect arguments pro and con keeping the position of "Decision Outcome" as is.

Rendered ADR: https://github.com/adr/madr/blob/add-0016/docs/decisions/0016-outcome-before-detailed-pros-cons.md

@cristiklein Could you provide some thoughts here?