### PR TITLE
Switch to markdownlint-cli2-action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Lint
-        uses: koppor/markdown-lint@switch-to-markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v5
         with:
-          args: '**/*.md'
+          globs: '**/*.md'


### PR DESCRIPTION
Instead of relying on a patched action, try with the "standard" action.

By the switch, we accept that we cannot lint `CHANGELOG.md`.

As soon as https://github.com/avto-dev/markdown-lint/issues/17 is resolved, we surely will be able to a) lint the CHANGELOG file and b) lint markdown files with one action. - In a follow-up PR, we could use [markdownlint-cli2-action](https://github.com/DavidAnson/markdownlint-cli2-action) for non-CHANGELOG.md files and [markdownlint action](https://github.com/avto-dev/markdown-lint) for `CHANGELOG.md`.