### PR TITLE
Fix decision 6 chosen option: repeat names

### DIFF
--- a/docs/decisions/0006-use-names-as-identifier.md
+++ b/docs/decisions/0006-use-names-as-identifier.md
@@ -21,4 +21,4 @@ An option is listed at "Considered Options" and repeated at "Pros and Cons of th
 
 ## Decision Outcome
 
-Chosen option: "Assign an identifier to an option", because 1) there is no markdown standard for identifiers, 2) the document is harder to read if there are multiple options.
+Chosen option: "Repeat all option names if they occur", because 1) there is no markdown standard for identifiers, 2) the document is harder to read if there are multiple options which must be remembered.


### PR DESCRIPTION
All subsequent madr decision documents continue to use  the "Repeat all option names if they occur", but this madr incorrectly stated that the identifier option was chosen.

For example https://github.com/adr/madr/blob/main/template/adr-template.md?plain=1#L32:

```md
## Decision Outcome

Chosen option: "{title of option 1}", because
```