### PR TITLE
Put the content of `status:` in quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Put the content of `status:` in quotes to tell YAML it's a string. [#91](https://github.com/adr/madr/issues/91)
+
 ## [3.0.0] – 2022-10-09
 
 ### Added

--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -5,7 +5,7 @@ nav_order: 100
 title: ADR Template
 
 # These are optional elements. Feel free to remove any of them.
-# status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}
+# status: "{proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}"
 # date: {YYYY-MM-DD when the decision was last updated}
 # deciders: {list everyone involved in the decision}
 # consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}

--- a/template/adr-template.md
+++ b/template/adr-template.md
@@ -1,6 +1,6 @@
 ---
 # These are optional elements. Feel free to remove any of them.
-status: {proposed | rejected | accepted | deprecated | … | superseded by ADR-0005 <0005-example.md>}
+status: "{proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}"
 date: {YYYY-MM-DD when the decision was last updated}
 deciders: {list everyone involved in the decision}
 consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}


### PR DESCRIPTION
Fixes https://github.com/adr/madr/issues/91

Opening https://github.com/adr/madr/blob/fix-91/template/adr-template.md does not show any error any more.