### PR TITLE
Fix misspelling in example for long version

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -62,7 +62,7 @@ Chosen option: "Plain JUnit5", because comes out best (see below).
 ### Consequences
 
 * Good, because tests are more readable
-* Goop, because more easy to write tests
+* Good, because more easy to write tests
 * Good, because more readable assertions
 * Bad, because more complicated testing leads to more complicated assertions
 


### PR DESCRIPTION
Goop, because it fixes the misspelling.
Bad, because "goop" was delightful.