### PR TITLE
Rename to "... Architectural ..." again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Put the content of `status:` in quotes to tell YAML it's a string. [#91](https://github.com/adr/madr/issues/91)
 - Renamed "Validation" to "Confirmation" and put it as sub element of "Decision Outcome". [#87](https://github.com/adr/madr/pull/87)
+- Rename template name "Markdown Any Decision Record" back to "Markdown Architectural Decision Record"
+- Rename `0000-use-markdown-any-decision-records.md` to `0000-use-madr.md`.
 
 ## [3.0.0] – 2022-10-09
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Markdown Any Decision Records
+# Markdown Architectural Decision Records
 
-> "Markdown Any Decision Records" (MADR) `[ˈmæɾɚ]` – decisions that [matter `[ˈmæɾɚ]`](https://en.wiktionary.org/wiki/matter#Pronunciation).
+> "Markdown Architectural Decision Records" (MADR) `[ˈmæɾɚ]` – decisions that [matter `[ˈmæɾɚ]`](https://en.wiktionary.org/wiki/matter#Pronunciation).
 
 For user documentation, please head to <https://adr.github.io/madr/>.
 
@@ -62,8 +62,8 @@ In case you get errors regarding `Gemfile.lock`, just delete `Gemfile.lock` and 
 5. Update `CHANGELOG.md`.
 6. Check that the YAML front matter in `docs/decisions/adr-template.md` is kept.
 7. Copy `.markdownlint.yml` to `template/.markdownlint.yml`
-8. Adapt the version reference in `template/0000-use-markdown-any-decision-records.md`.
-9. Copy `template/0000-use-markdown-any-decision-records.md` to `docs/decisions/0000-use-markdown-any-decision-records.md`.
+8. Adapt the version reference in `template/0000-use-madr.md`.
+9. Copy `template/0000-use-madr.md` to `docs/decisions/0000-use-madr.md`.
 10. Update `package.json`
 11. Publish to [npmjs](https://www.npmjs.com/package/madr) using [release-it](https://www.npmjs.com/package/release-it) (do not create a release on GitHub). This also does a commit.
 12. Create GitHub release using [github-release-from-changelog](https://www.npmjs.com/package/github-release-from-changelog).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: "MADR"
-desription: Markdown Any Decisions Records
+desription: Markdown Architectural Decisions Records
 repository: adr/madr
 theme: just-the-docs
 color_scheme: light

--- a/docs/decisions/0000-use-madr.md
+++ b/docs/decisions/0000-use-madr.md
@@ -2,16 +2,16 @@
 parent: Decisions
 nav_order: 0
 ---
-# Use Markdown Any Decision Records
+# Use Markdown Architectural Decision Records
 
 ## Context and Problem Statement
 
-We want to record any decisions made in this project independent whether decisions concern the architecture ("architectural decision record"), the code, or other fields.
+We want to record architectural decisions made in this project independent whether decisions concern the architecture ("architectural decision record"), the code, or other fields.
 Which format and structure should these records follow?
 
 ## Considered Options
 
-* [MADR](https://adr.github.io/madr/) 3.0.0 – The Markdown Any Decision Records
+* [MADR](https://adr.github.io/madr/) 4.0.0 – The Markdown Architectural Decision Records
 * [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
 * [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) – The Y-Statements
 * Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,15 +3,15 @@ nav_order: 1
 title: About MADR
 ---
 <!-- markdownlint-disable MD025 -->
-# Markdown Any Decision Records [![part of ADR](https://img.shields.io/badge/part_of-ADR-blue.svg)](https://adr.github.io)
+# Markdown Architectural Decision Records [![part of ADR](https://img.shields.io/badge/part_of-ADR-blue.svg)](https://adr.github.io)
 
-> "Markdown Any Decision Records" (MADR) `[ˈmæɾɚ]` – decisions that [matter `[ˈmæɾɚ]`](https://en.wiktionary.org/wiki/matter#Pronunciation).
+> "Markdown Architectural Decision Records" (MADR) `[ˈmæɾɚ]` – decisions that [matter `[ˈmæɾɚ]`](https://en.wiktionary.org/wiki/matter#Pronunciation).
 
-<!-- text source: https://adr.github.io/ -->
-An Architectural Decision (AD) is a justified software design choice that addresses a functional or non-functional requirement that is architecturally significant.
-An [Architectural Decision Record (ADR)](https://adr.github.io/) captures a single AD and its rationale.
-MADR is a lean template to capture any decisions in a structured way.
-The template originated from capturing architectural decisions and developed to a template allowing to capture any decisions taken.
+<!-- text inspiration: https://adr.github.io/ -->
+An Architectural Decision (AD) is a justified software design choice that addresses a functional or non-functional requirement of architectural significance.
+This decision is documented in an Architectural Decision Record (ADR), which details a single AD and its underlying rationale.
+To capture these records in a lean way, the Markdown Architectural Decision Records (MADRs) have been invented:
+MADR is a streamlined template for recording archictural significant decisions in a structured manner.
 
 ## Contents
 
@@ -28,6 +28,8 @@ The template originated from capturing architectural decisions and developed to 
 
 ## News
 
+* 2024-05-xx: Release of MADR 4.0.0
+  * To strengthen the importance for decisions in software architecture work, MADR spells out "Markdown Architectural Decision Records". They can still be used to 
 * 2023-04-05: Two new Medium stories ["How to create Architectural Decision Records (ADRs) — and how not to"](https://medium.com/olzzio/how-to-create-architectural-decision-records-adrs-and-how-not-to-93b5b4b33080) and ["How to review Architectural Decision Records (ADRs) — and how not to"](https://medium.com/olzzio/how-to-review-architectural-decision-records-adrs-and-how-not-to-2707652db196). Metaphors, patterns, anti-patterns, checklists applicable (but not limited) to MADRs.
 * 2022-11-22. MADR Version 1.0 was released five years ago. A new blog post ["The Markdown ADR (MADR) Template Explained and Distilled"](https://medium.com/olzzio/the-markdown-adr-madr-template-explained-and-distilled-b67603ec95bb) is available on Medium.
 * 2022-10-09: Release of MADR 3.0.0.\

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,8 @@ MADR is a streamlined template for recording archictural significant decisions i
 ## News
 
 * 2024-05-xx: Release of MADR 4.0.0
-  * To strengthen the importance for decisions in software architecture work, MADR spells out "Markdown Architectural Decision Records". They can still be used to 
+  * To strengthen the importance for decisions in software architecture work, MADR spells out "Markdown Architectural Decision Records".
+    They can still be used to sustain any decision, our focus is on architectural decisions.
 * 2023-04-05: Two new Medium stories ["How to create Architectural Decision Records (ADRs) — and how not to"](https://medium.com/olzzio/how-to-create-architectural-decision-records-adrs-and-how-not-to-93b5b4b33080) and ["How to review Architectural Decision Records (ADRs) — and how not to"](https://medium.com/olzzio/how-to-review-architectural-decision-records-adrs-and-how-not-to-2707652db196). Metaphors, patterns, anti-patterns, checklists applicable (but not limited) to MADRs.
 * 2022-11-22. MADR Version 1.0 was released five years ago. A new blog post ["The Markdown ADR (MADR) Template Explained and Distilled"](https://medium.com/olzzio/the-markdown-adr-madr-template-explained-and-distilled-b67603ec95bb) is available on Medium.
 * 2022-10-09: Release of MADR 3.0.0.\

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,9 @@ title: About MADR
 
 > "Markdown Any Decision Records" (MADR) `[ˈmæɾɚ]` – decisions that [matter `[ˈmæɾɚ]`](https://en.wiktionary.org/wiki/matter#Pronunciation).
 
+<!-- text source: https://adr.github.io/ -->
+An Architectural Decision (AD) is a justified software design choice that addresses a functional or non-functional requirement that is architecturally significant.
+An [Architectural Decision Record (ADR)](https://adr.github.io/) captures a single AD and its rationale.
 MADR is a lean template to capture any decisions in a structured way.
 The template originated from capturing architectural decisions and developed to a template allowing to capture any decisions taken.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "madr",
-  "description": "Markdown Any Decision Records",
+  "description": "Markdown Architectural Decision Records",
   "keywords": [
     "adr",
     "decision record",

--- a/template/0000-use-markdown-any-decision-records.md
+++ b/template/0000-use-markdown-any-decision-records.md
@@ -1,13 +1,13 @@
-# Use Markdown Any Decision Records
+# Use Markdown Architectural Decision Records
 
 ## Context and Problem Statement
 
-We want to record any decisions made in this project independent whether decisions concern the architecture ("architectural decision record"), the code, or other fields.
+We want to record architectural decisions made in this project independent whether decisions concern the architecture ("architectural decision record"), the code, or other fields.
 Which format and structure should these records follow?
 
 ## Considered Options
 
-* [MADR](https://adr.github.io/madr/) 3.0.0 – The Markdown Any Decision Records
+* [MADR](https://adr.github.io/madr/) 4.0.0 – The Markdown Architectural Decision Records
 * [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
 * [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) – The Y-Statements
 * Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
@@ -15,7 +15,7 @@ Which format and structure should these records follow?
 
 ## Decision Outcome
 
-Chosen option: "MADR 3.0.0", because
+Chosen option: "MADR 4.0.0", because
 
 * Implicit assumptions should be made explicit.
   Design documentation is important to enable people understanding the decisions later on.


### PR DESCRIPTION
Motivation: We want to strengthen the architecture aspect of MADR. A general usage is "OK", but for publicity reasons, we should stick with the original intention.

Also fixes https://github.com/adr/madr/issues/110