### PR TITLE
Switch to dark theme (and update jtd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,17 @@ and go to <http://localhost:4000/madr/> in your browser.
 On Windows, using a dockerized environment is recommended:
 
 ```terminal
-docker run -p 4000:4000 --rm --volume="C:\git-repositories\adr.github.io\madr\docs":/srv/jekyll jekyll/jekyll:4 jekyll serve
+docker run -p 4000:4000 --rm -v "C:\git-repositories\adr.github.io\madr\docs":/site bretfisher/jekyll-serve
 ```
 
 In case you get errors regarding `Gemfile.lock`, just delete `Gemfile.lock` and rerun.
+
+## Updating just-the-docs
+
+* Adapt `docs/Gemfile` to use newer just-the-docs version. Thereby check <https://github.com/just-the-docs/just-the-docs-template/blob/main/Gemfile> for versions.
+* Delete `docs/Gemfile.lock`. Start `bundle install`.
+* Check <https://github.com/just-the-docs/just-the-docs/blob/main/CHANGELOG.md>.
+* Check <https://just-the-docs.com/migration/>.
 
 ## Releasing a new version
 

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem "jekyll", "~> 4.3.2"
+gem "jekyll", "~> 4.3.3"
 
-gem "just-the-docs", "0.6.2"
+gem "just-the-docs", "0.8.2"
 
 gem 'jekyll-titles-from-headings'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,21 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.15.5)
+    ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.24.3-x86_64-linux)
+    google-protobuf (4.26.1-x86_64-linux)
+      rake (>= 13)
     http_parser.rb (0.8.0)
-    i18n (1.14.1)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.2)
+    jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -41,7 +42,7 @@ GEM
       jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    just-the-docs (0.6.2)
+    just-the-docs (0.8.2)
       jekyll (>= 3.8.5)
       jekyll-include-cache
       jekyll-seo-tag (>= 2.0)
@@ -51,35 +52,38 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.8.0)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.3)
-    rake (13.0.6)
+    public_suffix (5.0.5)
+    rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.6)
-    rouge (4.1.3)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
+    rouge (4.2.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.63.6)
-      google-protobuf (~> 3.23)
+    sass-embedded (1.77.1)
+      google-protobuf (>= 3.25, < 5.0)
       rake (>= 13.0.0)
+    strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.4.2)
+    unicode-display_width (2.5.0)
     webrick (1.8.1)
 
 PLATFORMS
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
-  jekyll (~> 4.3.2)
+  jekyll (~> 4.3.3)
   jekyll-titles-from-headings
-  just-the-docs (= 0.6.2)
+  just-the-docs (= 0.8.2)
 
 BUNDLED WITH
-   2.4.19
+   2.3.25

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,7 +2,7 @@ title: "MADR"
 desription: Markdown Architectural Decisions Records
 repository: adr/madr
 theme: just-the-docs
-color_scheme: light
+color_scheme: dark
 
 defaults:
   -


### PR DESCRIPTION
We got complaints about the color. The simple fix is to switch the color theme.

Old:

![grafik](https://github.com/adr/madr/assets/1366654/64600c1c-5d9e-42c0-a658-3379c4e8f0d2)

New:

![grafik](https://github.com/adr/madr/assets/1366654/fcddc468-0f04-4523-bb72-0301d7c34d29)
