### PR TITLE
Allow markdown detection for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+*.md linguist-documentation=false
+*.md linguist-detectable


### PR DESCRIPTION
This enables GitHub's Linguist to detect markdown files when computing the repo's languages. See [this repo](https://github.com/ggorlen/resources/) for an example:

![image of linguist detecting markdown](https://github.com/user-attachments/assets/53d756bb-b6ed-4e87-b914-bc511d93f4a7)
