### PR TITLE
Add real link

### DIFF
--- a/template/adr-template.md
+++ b/template/adr-template.md
@@ -1,6 +1,6 @@
 ---
 # These are optional elements. Feel free to remove any of them.
-status: "{proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}"
+status: "{proposed | rejected | accepted | deprecated | … | superseded by [ADR-0000](0000-use-markdown-architectural-decision-records.md)}"
 date: {YYYY-MM-DD when the decision was last updated}
 decision-makers: {list everyone involved in the decision}
 consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}


### PR DESCRIPTION
When using a link checker, the link to ´0005-example.md` fails.

Either we add a hint on README.md for link checkers (and try to provide example configurations) or "just" link to an existing file - and hope that users know what to do here. I opted for the second option.