### PR TITLE
Fix typos of the word "minimal"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Bare an minimal templates: [#88](https://github.com/adr/madr/issues/88)
-  - [`adr-template-minmal.md`](template/adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
+  - [`adr-template-minimal.md`](template/adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
   - [`adr-template-bare.md`](template/adr-template-bare.md) has all sections, wich are empty (no explanations).
   - [`adr-template-bare-minimal.md`](template/adr-template-bare-minimal.md) has the mandatory sections, without explanations. <!-- ### Consequences also contained, though marked as "optional" -->
 - Added example for "Confirmation". [#135](https://github.com/adr/madr/issues/135)

--- a/template/README.md
+++ b/template/README.md
@@ -3,7 +3,7 @@
 For new Architectural Decision Records (ADRs), please use one of the following templates as a starting point:
 
 * [adr-template.md](adr-template.md) has all sections, with explanations about them.
-* [adr-template-minmal.md](adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
+* [adr-template-minimal.md](adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
 * [adr-template-bare.md](adr-template-bare.md) has all sections, wich are empty (no explanations).
 * [adr-template-bare-minimal.md](adr-template-bare-minimal.md) has the mandatory sections, without explanations. <!-- ### Consequences also contained, though marked as "optional" -->
 


### PR DESCRIPTION
Fixed a few typos of "minimal" as "minmal".