### PR TITLE
Fix typo: `minmal` -> `minimal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Bare an minimal templates: [#88](https://github.com/adr/madr/issues/88)
-  - [`adr-template-minmal.md`](template/adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
+  - [`adr-template-minimal.md`](template/adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
   - [`adr-template-bare.md`](template/adr-template-bare.md) has all sections, which are empty (no explanations).
   - [`adr-template-bare-minimal.md`](template/adr-template-bare-minimal.md) has the mandatory sections, without explanations. <!-- ### Consequences also contained, though marked as "optional" -->
 - Added example for "Confirmation". [#135](https://github.com/adr/madr/issues/135)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For user documentation, please head to <https://adr.github.io/madr/>.
 ## Quick start
 
 * [`adr-template.md`](template/adr-template.md) has all sections, with explanations about them.
-* [`adr-template-minmal.md`](template/adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
+* [`adr-template-minimal.md`](template/adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
 * [`adr-template-bare.md`](template/adr-template-bare.md) has all sections, which are empty (no explanations).
 * [`adr-template-bare-minimal.md`](template/adr-template-bare-minimal.md) has the mandatory sections, without explanations. <!-- ### Consequences also contained, though marked as "optional" -->
 

--- a/template/README.md
+++ b/template/README.md
@@ -3,7 +3,7 @@
 For new Architectural Decision Records (ADRs), please use one of the following templates as a starting point:
 
 * [adr-template.md](adr-template.md) has all sections, with explanations about them.
-* [adr-template-minmal.md](adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
+* [adr-template-minimal.md](adr-template-minimal.md) only contains mandatory sections, with explanations about them. <!-- ### Consequences also contained, though marked as "optional" -->
 * [adr-template-bare.md](adr-template-bare.md) has all sections, which are empty (no explanations).
 * [adr-template-bare-minimal.md](adr-template-bare-minimal.md) has the mandatory sections, without explanations. <!-- ### Consequences also contained, though marked as "optional" -->
 


### PR DESCRIPTION
Fixes typo introduced in #224 (`minmal` -> `minimal`).