### PR TITLE
docs: fix two typos in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The current state is rendered at <https://develop--madr-develop.netlify.app/>.
 As soon as a pull request is made, [netlify](https://www.netlify.com/) kicks off a build.
 After a successful build, the link to the build is put as a comment to the pull request for inspection.
 
-We use `develop` as branch name, because the name `main` does not definitively indicate whether it is the latest releae or the development version.
+We use `develop` as branch name, because the name `main` does not definitively indicate whether it is the latest release or the development version.
 
 ## Template: Patches to releases
 
@@ -24,4 +24,4 @@ It is a branch, because the release version changes (and there are git users who
 Please submit a pull request to that branch.
 In case there are multiple fixes, we create a new branch `develop/v{x}` on demand.
 
-Reasing: Wish at [#92](https://github.com/adr/madr/issues/92)
+Reasoning: Wish at [#92](https://github.com/adr/madr/issues/92)


### PR DESCRIPTION
Two spelling fixes in `CONTRIBUTING.md`:

- line 17 — `releae` → `release`
- line 27 — `Reasing` → `Reasoning`

No content changes. Targeting `develop` per the default branch.